### PR TITLE
Add init system for Docker and env var to control test mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3-alpine
+RUN apk add --no-cache dumb-init
 ADD . /opt/accounting.client
 ADD ./b2sharecollector /etc/periodic/hourly/b2sharecollector
 RUN chmod +x /etc/periodic/hourly/b2sharecollector
@@ -8,5 +9,7 @@ RUN pip3 install --no-cache .
 
 ENV ACCOUNTING_TEST_MODE = True
 ENV ACCOUNTING_B2SHARE_SUPERADMIN_API_KEY = ""
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 CMD ["sh", "-c", "echo \"starting crond\" && (crond) && echo \"tailing...\" && : >> /srv/app/.accounting.log && tail -f /srv/app/.accounting.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,7 @@ WORKDIR /opt/accounting.client
 
 RUN pip3 install --no-cache .
 
+ENV ACCOUNTING_TEST_MODE = True
+ENV ACCOUNTING_B2SHARE_SUPERADMIN_API_KEY = ""
+
 CMD ["sh", "-c", "echo \"starting crond\" && (crond) && echo \"tailing...\" && : >> /srv/app/.accounting.log && tail -f /srv/app/.accounting.log"]

--- a/b2sharecollector
+++ b/b2sharecollector
@@ -8,8 +8,7 @@ if [ -d $APP_DIR ]; then
 		# "run if .success file hasn't been touched in 24h and touch file if successfully run
 		if find "$filename.success" -mmin +1439 |read
 		then
-			source /opt/accounting.client/.env
-			B2SHAREcollector -tv -c $filename
+			B2SHAREcollector -v -c $filename
 			if [ $? -eq 0 ]
 			then
 				touch $filename.success

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,15 @@
 version: "2"
 services:
     accounting:
-        image: eudat.accounting.client
+        image: eudat.accounting.client:latest
         restart: "unless-stopped"
         volumes:
+            # cronjob collects stats according to these config files
+            # (one per community)
             - "./conf:/srv/app/conf"
-            - "./b2sharecollector:/etc/periodic/hourly/b2sharecollector"
+            # Uncomment to overwrite cronjob in Docker Image
+            # - "./b2sharecollector:/etc/periodic/hourly/b2sharecollector"
+        environment:
+            - "ACCOUNTING_TEST_MODE=True"
+            # - "ACCOUNTING_TEST_MODE=${ACCOUNTING_TEST_MODE}"
+            - "ACCOUNTING_B2SHARE_SUPERADMIN_API_KEY=${ACCOUNTING_B2SHARE_SUPERADMIN_API_KEY}"

--- a/src/eudat/accounting/b2share/b2share_collector.py
+++ b/src/eudat/accounting/b2share/b2share_collector.py
@@ -57,7 +57,8 @@ class Configuration(object):
         self.b2share_url = self.fileparser.get('B2SHARE', 'url')
 
         # Configuration provided with environment variables
-        self.api_token = os.getenv('B2SHARE_SUPERADMIN_API_KEY', None)
+        self.api_token = os.getenv('ACCOUNTING_B2SHARE_SUPERADMIN_API_KEY', None)
+        self.test_mode = os.getenv('ACCOUNTING_TEST_MODE', False)
 
         # create a file handler
         handler = logging.handlers.RotatingFileHandler(self.logfile, \
@@ -126,7 +127,7 @@ class EUDATAccounting(object):
         data = utils.getData(args)
         self.logger.info("Data as query string: " + data)
 
-        if args.test:
+        if args.test or self.conf.test_mode:
             print("Test: Would send the following data: " \
                 + data)
             return None


### PR DESCRIPTION
* Add dumb-init (https://github.com/Yelp/dumb-init) as init system to handle SIGTERM situations (e.g. `docker-compose down`, ctrl+c, etc.)

* Add environment variable ('ACCOUNTING_TEST_MODE') to control test mode. Eases Docker deployments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hjhsalo/eudat.accounting.client/6)
<!-- Reviewable:end -->
